### PR TITLE
Changed Ionic Beta Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@ FROM beevelop/cordova
 
 MAINTAINER Maik Hummel <m@ikhummel.com>
 
-ENV IONIC_VERSION=v2-beta
+ENV IONIC_VERSION=beta
 
-RUN apt-get -qq update && apt-get -qq install -y git && \
-    npm i -g --unsafe-perm driftyco/ionic-cli#${IONIC_VERSION}
+RUN npm i -g --unsafe-perm ionic@${IONIC_VERSION}
 
 CMD ["ionic"]


### PR DESCRIPTION
Ionic was being installed from a tag on the driftyco/ionic-cli GitHub repo that doesn't seem to work. I switched it to install from NPM with `npm install -g ionic@beta` which currently installs `2.0.0-beta.37`.  That change also simplifies the Dockerfile since an update to git is no longer required. 