### PR TITLE
Addin @ionic/lab installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ ENV IONIC_VERSION 4.1.2
 
 RUN apt-get update && apt-get install -y git bzip2 openssh-client && \
     npm i -g --unsafe-perm ionic@${IONIC_VERSION} && \
+    npm i -g @ionic/lab \
     ionic --no-interactive config set -g daemon.updates false && \
     rm -rf /var/lib/apt/lists/* && apt-get clean


### PR DESCRIPTION
Because it's required to run "ionic lab" command ; and it's not defaultely installed on ionic 4